### PR TITLE
fix: make CUDA=0 PYTHON=1 compilation work. fix typo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ FLAGS := ${COMMON_FLAGS} -arch sm_75 --compiler-options -Wall,-fPIC \
 COMPILE_FLAGS := ${FLAGS}
 COMPILER := nvcc
 else
-	FLAGS := ${COMMON_FLAGS} -Wall
+	FLAGS := ${COMMON_FLAGS} -Wall -fPIC
 
 	ifeq (${MACOS}, 1)
 		FLAGS += -Xclang -fopenmp
@@ -61,7 +61,7 @@ build/cubff_py.o: cubff_py.cc common.h
 	${COMPILER} -c ${COMPILE_FLAGS} $< -o $@ $(shell python3 -m pybind11 --includes)
 
 bin/cubff${PYEXT}: build/cubff_py.o build/common.o ${LANGS}
-	${COMPILER} -shared $^ ${COMPILE_FLAGS} ${LINK_FLAGS} -o $@
+	${COMPILER} -shared $^ ${FLAGS} ${LINK_FLAGS} -o $@
 
 .PHONY:
 clean:


### PR DESCRIPTION
We need to build with `-fPIC` due to the Python .so we want to build, even if building not for CUDA.

Use ${FLAGS} instead of ${COMPILE_FLAGS} for the linking step (otherwise the useless-in-context `-x cpp` is provided and clang actually validly complains about it being useless).