### PR TITLE
Fix off-by-one bounds check in CheckSelfRep kernel

### DIFF
--- a/common_language.h
+++ b/common_language.h
@@ -207,7 +207,7 @@ __global__ void CheckSelfRep(uint8_t *programs, size_t seed,
   constexpr size_t kNumIters = 13;
   constexpr size_t kNumExtraGens = 4;
   uint8_t tapes[kNumIters][2 * kSingleTapeSize] = {};
-  if (index > num_programs) return;
+  if (index >= num_programs) return;
   uint64_t local_seed = SplitMix64(num_programs * seed + index);
   for (size_t i = 0; i < kNumIters; i++) {
     bool eval_debug = false;


### PR DESCRIPTION
The guard used > instead of >=, so a thread with index == num_programs would not be skipped and would read one program past the end of the programs buffer. In practice the kernel is dispatched with exactly num_programs threads (indices 0..num_programs-1), so this index was never reached — but the check was semantically wrong.

Discovered during review of a Metal port, which contains the corrected >= in its Metal shader equivalent.